### PR TITLE
Fix "BIGINT UNSIGNED VALUE IS out of range" on total column

### DIFF
--- a/dashproducts.php
+++ b/dashproducts.php
@@ -198,7 +198,12 @@ class dashproducts extends Module
 					SELECT
 						product_id,
 						product_name,
-						SUM(product_quantity-product_quantity_refunded-product_quantity_return-product_quantity_reinjected) as total,
+						SUM(
+			                            CAST(od.product_quantity AS SIGNED) -
+			                            CAST(od.product_quantity_refunded AS SIGNED) -
+			                            CAST(od.product_quantity_return AS SIGNED) -
+			                            CAST(od.product_quantity_reinjected AS SIGNED)
+			                        ) AS total,
 						p.price as price,
 						pa.price as price_attribute,
 						SUM(total_price_tax_excl / conversion_rate) as sales,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Sometimes you get a MySQL error "BIGINT UNSIGNED VALUE IS out of range" on the getTableBestSellers() query and the module panel appears blank
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | It ocurrs when the sum of product_quantity_refunded, product_quantity_return, product_quantity_reinjected its bigger than product_quantity. It happens due a subtraction operation resulting in a negative number while using unsigned data types. In MySQL, subtracting unsigned integers that lead to negative results will cause a "BIGINT UNSIGNED VALUE IS out of range" error because unsigned integers cannot represent negative numbers.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

